### PR TITLE
Update _nmap-parse-output

### DIFF
--- a/_nmap-parse-output
+++ b/_nmap-parse-output
@@ -6,7 +6,7 @@ _nmap-parse-output_completions()
   if [ -h "$NPO_SCRIPT" ]; then
     local NPO_SCRIPT="$(readlink "$NPO_SCRIPT")"
   fi
-  local NMAP_PARSE_OUTPUT_DIR="$( dirname "$NPO_SCRIPT" )/nmap-parse-output-xslt"
+  local NMAP_PARSE_OUTPUT_DIR="$(find ~ -name '_nmap-parse-output' -printf "%h\n" 2>/dev/null)/nmap-parse-output-xslt"
   
   if [ -n "$ZSH_VERSION" ]; then
     # ZSH


### PR DESCRIPTION
Add a proper way to get directory path for when you place the command as an alias so as to get bash and zsh completion from any directory.